### PR TITLE
Add optional meta when capture()-ing

### DIFF
--- a/requestyai/ainsights/client.py
+++ b/requestyai/ainsights/client.py
@@ -29,6 +29,7 @@ class AInsights:
         response: ChatCompletion,
         messages: Union[str, list[str], list[dict]],
         args: dict = {},
+        meta: dict = {},
         user_id: Optional[str] = None,
     ) -> Future:
         """Capture an event by sending it to the insights endpoint.
@@ -37,7 +38,11 @@ class AInsights:
         """
 
         event = AInsightsEvent(
-            response=response, messages=messages, args=args, user_id=user_id
+            response=response,
+            messages=messages,
+            args=args,
+            meta=meta,
+            user_id=user_id,
         )
 
         return self.__client.put(url=self.__URL, data=event.model_dump_json())

--- a/requestyai/ainsights/types/event.py
+++ b/requestyai/ainsights/types/event.py
@@ -6,8 +6,7 @@ from pydantic import BaseModel
 
 class AInsightsEvent(BaseModel):
     response: ChatCompletion
-
     messages: Union[str, list[str], list[dict]]
     args: dict
-
+    meta: dict
     user_id: Optional[str]

--- a/tests/ainsights/test_client.py
+++ b/tests/ainsights/test_client.py
@@ -125,6 +125,19 @@ class TestAInsights:
         obj = json.loads(call_data)
         assert obj["user_id"] == user_id
 
+    def test_capture_meta(self, insights, response):
+        meta = {"page": "ask ai", "latency": 1.23}
+        messages = [{"role": "user", "content": "test"}]
+        insights.capture(
+            response=response,
+            messages=messages,
+            meta=meta,
+        )
+        insights._AInsights__client.put.assert_called_once()
+        call_data = insights._AInsights__client.put.call_args[1]["data"]
+        obj = json.loads(call_data)
+        assert obj["meta"] == meta
+
     def test_build(self):
         api_key = "test_key"
         custom_url = "https://custom.api.com"

--- a/tests/ainsights/test_client.py
+++ b/tests/ainsights/test_client.py
@@ -67,32 +67,63 @@ class TestAInsights:
         client = AInsights(client=mock_async_client)
         assert client._AInsights__client == mock_async_client
 
-    def test_capture_with_string_message(self, insights, response):
-        insights.capture(response=response, messages="test message")
+    def test_capture_response(self, insights, response):
+        message = "test message"
+        insights.capture(response=response, messages=message)
         insights._AInsights__client.put.assert_called_once()
         call_data = insights._AInsights__client.put.call_args[1]["data"]
         obj = json.loads(call_data)
         assert obj["response"] == response.model_dump()
 
-    def test_capture_with_list_messages(self, insights, response):
+    def test_capture_messages_string(self, insights, response):
+        messages = "test message"
+        insights.capture(response=response, messages=messages)
+        insights._AInsights__client.put.assert_called_once()
+        call_data = insights._AInsights__client.put.call_args[1]["data"]
+        obj = json.loads(call_data)
+        assert obj["messages"] == messages
+
+    def test_capture_messages_list_of_strings(self, insights, response):
         messages = ["message1", "message2"]
         insights.capture(response=response, messages=messages)
         insights._AInsights__client.put.assert_called_once()
         call_data = insights._AInsights__client.put.call_args[1]["data"]
         obj = json.loads(call_data)
-        assert obj["response"] == response.model_dump()
+        assert obj["messages"] == messages
 
-    def test_capture_with_dict_messages(self, insights, response):
+    def test_capture_messages_list_of_dicts(self, insights, response):
         messages = [{"role": "user", "content": "test"}]
+        insights.capture(response=response, messages=messages)
+        insights._AInsights__client.put.assert_called_once()
+        call_data = insights._AInsights__client.put.call_args[1]["data"]
+        obj = json.loads(call_data)
+        assert obj["messages"] == messages
+
+    def test_capture_args(self, insights, response):
+        args = {"model": "gpt-4o-mini", "temperature": 0.7, "max_tokens": 150}
+        messages = "test message"
         insights.capture(
             response=response,
             messages=messages,
-            user_id="test_user",
+            args=args,
         )
         insights._AInsights__client.put.assert_called_once()
         call_data = insights._AInsights__client.put.call_args[1]["data"]
         obj = json.loads(call_data)
-        assert obj["response"] == response.model_dump()
+        assert obj["args"] == args
+
+    def test_capture_user_id(self, insights, response):
+        user_id = "test_user"
+        messages = [{"role": "user", "content": "test"}]
+        insights.capture(
+            response=response,
+            messages=messages,
+            user_id=user_id,
+        )
+        insights._AInsights__client.put.assert_called_once()
+        call_data = insights._AInsights__client.put.call_args[1]["data"]
+        obj = json.loads(call_data)
+        assert obj["user_id"] == user_id
 
     def test_build(self):
         api_key = "test_key"


### PR DESCRIPTION
When calling `capture()` the user can specify a `meta` dictionary with any properties.
The user can then dissect their insights using those values.