### PR TITLE
Release v0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "requestyai"
-version = "0.3.3"
+version = "0.3.4"
 description = "Deliver AI products in days, not months, using requesty.ai"
 authors = ["RequestyAI <support@requesty.ai>"]
 readme = "README.md"

--- a/requestyai/ainsights/client.py
+++ b/requestyai/ainsights/client.py
@@ -29,6 +29,7 @@ class AInsights:
         response: ChatCompletion,
         messages: Union[str, list[str], list[dict]],
         args: dict = {},
+        meta: dict = {},
         user_id: Optional[str] = None,
     ) -> Future:
         """Capture an event by sending it to the insights endpoint.
@@ -37,7 +38,11 @@ class AInsights:
         """
 
         event = AInsightsEvent(
-            response=response, messages=messages, args=args, user_id=user_id
+            response=response,
+            messages=messages,
+            args=args,
+            meta=meta,
+            user_id=user_id,
         )
 
         return self.__client.put(url=self.__URL, data=event.model_dump_json())

--- a/requestyai/ainsights/client.py
+++ b/requestyai/ainsights/client.py
@@ -48,7 +48,7 @@ class AInsights:
         return self.__client.put(url=self.__URL, data=event.model_dump_json())
 
     @staticmethod
-    def new_client(api_key: str, base_url: Optional[str] = None) -> "AInsights":
+    def new_client(*, api_key: str, base_url: Optional[str] = None) -> "AInsights":
         """The standard way of creating new InsightsClient objects.
         As the InsightsClient uses dependency injections, this constructor
         handles the heavy lifting for you

--- a/requestyai/ainsights/client.py
+++ b/requestyai/ainsights/client.py
@@ -13,7 +13,7 @@ class AInsights:
     of events to the server
     """
 
-    DEFAULT_BASE_URL = "https://api.requesty.ai"
+    DEFAULT_BASE_URL = "https://ingestion.requesty.ai"
 
     __URL = "insight"
 

--- a/requestyai/ainsights/client.py
+++ b/requestyai/ainsights/client.py
@@ -48,11 +48,13 @@ class AInsights:
         return self.__client.put(url=self.__URL, data=event.model_dump_json())
 
     @staticmethod
-    def new_client(api_key: str, base_url: str = DEFAULT_BASE_URL) -> "AInsights":
+    def new_client(api_key: str, base_url: Optional[str] = None) -> "AInsights":
         """The standard way of creating new InsightsClient objects.
         As the InsightsClient uses dependency injections, this constructor
         handles the heavy lifting for you
         """
+
+        base_url = base_url if base_url is not None else AInsights.DEFAULT_BASE_URL
 
         headers = {
             "Content-Type": "application/json",

--- a/requestyai/ainsights/types/event.py
+++ b/requestyai/ainsights/types/event.py
@@ -6,8 +6,7 @@ from pydantic import BaseModel
 
 class AInsightsEvent(BaseModel):
     response: ChatCompletion
-
     messages: Union[str, list[str], list[dict]]
     args: dict
-
+    meta: dict
     user_id: Optional[str]

--- a/samples/openai/client_instance.py
+++ b/samples/openai/client_instance.py
@@ -49,7 +49,7 @@ def run(*, requesty_key_file, openai_key_file, base_url):
     requesty_key = read_file(requesty_key_file)
     openai_key = read_file(openai_key_file)
 
-    ainsights_client = AInsights.new_client(requesty_key, base_url)
+    ainsights_client = AInsights.new_client(api_key=requesty_key, base_url=base_url)
 
     openai_client = OpenAI(api_key=openai_key)
     openai_args = {"model": "gpt-4o-mini", "temperature": 0.7, "max_tokens": 150}

--- a/samples/openai/client_instance.py
+++ b/samples/openai/client_instance.py
@@ -72,8 +72,6 @@ def run(*, requesty_key_file, openai_key_file, base_url):
 
 
 def main():
-    default_base_url = "https://api.requesty.ai"
-
     default_keys_dir = Path.home() / ".keys"
     default_requesty_key_file = default_keys_dir / "requesty"
     default_openai_key_file = default_keys_dir / "openai"
@@ -96,12 +94,7 @@ def main():
         help="File that contains OpenAI's API key (DEFAULT: %(default)s)",
     )
 
-    parser.add_argument(
-        "--base_url",
-        type=str,
-        default=default_base_url,
-        help="The base url (DEFAULT: %(default)s)",
-    )
+    parser.add_argument("--base_url", type=str, default=None, help="A custom base url")
 
     args = parser.parse_args()
 

--- a/samples/openai/client_singleton.py
+++ b/samples/openai/client_singleton.py
@@ -3,6 +3,4 @@ import os
 from requestyai import AInsights
 
 requesty_key = os.environ["REQUESTY_KEY"]
-insights = AInsights.new_client(
-    api_key=requesty_key, base_url="https://api.requesty.ai"
-)
+insights = AInsights.new_client(api_key=requesty_key)

--- a/samples/openai/client_singleton.py
+++ b/samples/openai/client_singleton.py
@@ -3,4 +3,5 @@ import os
 from requestyai import AInsights
 
 requesty_key = os.environ["REQUESTY_KEY"]
-insights = AInsights.new_client(api_key=requesty_key)
+base_url = os.environ.get("REQUESTY_BASE_URL", default=None)
+insights = AInsights.new_client(api_key=requesty_key, base_url=base_url)

--- a/samples/openai/client_tools.py
+++ b/samples/openai/client_tools.py
@@ -55,7 +55,7 @@ def run(*, requesty_key_file, openai_key_file, base_url):
     requesty_key = read_file(requesty_key_file)
     openai_key = read_file(openai_key_file)
 
-    ainsights_client = AInsights.new_client(requesty_key, base_url)
+    ainsights_client = AInsights.new_client(api_key=requesty_key, base_url=base_url)
 
     openai_client = OpenAI(api_key=openai_key)
     openai_args = {"model": "gpt-4o-mini", "temperature": 0.7, "max_tokens": 150}

--- a/samples/openai/client_tools.py
+++ b/samples/openai/client_tools.py
@@ -73,8 +73,6 @@ def run(*, requesty_key_file, openai_key_file, base_url):
 
 
 def main():
-    default_base_url = "https://api.requesty.ai"
-
     default_keys_dir = Path.home() / ".keys"
     default_requesty_key_file = default_keys_dir / "requesty"
     default_openai_key_file = default_keys_dir / "openai"
@@ -100,8 +98,8 @@ def main():
     parser.add_argument(
         "--base_url",
         type=str,
-        default=default_base_url,
-        help="The base url (DEFAULT: %(default)s)",
+        default=None,
+        help="A custom base url",
     )
 
     args = parser.parse_args()

--- a/tests/ainsights/test_client.py
+++ b/tests/ainsights/test_client.py
@@ -125,6 +125,19 @@ class TestAInsights:
         obj = json.loads(call_data)
         assert obj["user_id"] == user_id
 
+    def test_capture_meta(self, insights, response):
+        meta = {"page": "ask ai", "latency": 1.23}
+        messages = [{"role": "user", "content": "test"}]
+        insights.capture(
+            response=response,
+            messages=messages,
+            meta=meta,
+        )
+        insights._AInsights__client.put.assert_called_once()
+        call_data = insights._AInsights__client.put.call_args[1]["data"]
+        obj = json.loads(call_data)
+        assert obj["meta"] == meta
+
     def test_build(self):
         api_key = "test_key"
         custom_url = "https://custom.api.com"

--- a/tests/ainsights/test_client.py
+++ b/tests/ainsights/test_client.py
@@ -67,32 +67,63 @@ class TestAInsights:
         client = AInsights(client=mock_async_client)
         assert client._AInsights__client == mock_async_client
 
-    def test_capture_with_string_message(self, insights, response):
-        insights.capture(response=response, messages="test message")
+    def test_capture_response(self, insights, response):
+        message = "test message"
+        insights.capture(response=response, messages=message)
         insights._AInsights__client.put.assert_called_once()
         call_data = insights._AInsights__client.put.call_args[1]["data"]
         obj = json.loads(call_data)
         assert obj["response"] == response.model_dump()
 
-    def test_capture_with_list_messages(self, insights, response):
+    def test_capture_messages_string(self, insights, response):
+        messages = "test message"
+        insights.capture(response=response, messages=messages)
+        insights._AInsights__client.put.assert_called_once()
+        call_data = insights._AInsights__client.put.call_args[1]["data"]
+        obj = json.loads(call_data)
+        assert obj["messages"] == messages
+
+    def test_capture_messages_list_of_strings(self, insights, response):
         messages = ["message1", "message2"]
         insights.capture(response=response, messages=messages)
         insights._AInsights__client.put.assert_called_once()
         call_data = insights._AInsights__client.put.call_args[1]["data"]
         obj = json.loads(call_data)
-        assert obj["response"] == response.model_dump()
+        assert obj["messages"] == messages
 
-    def test_capture_with_dict_messages(self, insights, response):
+    def test_capture_messages_list_of_dicts(self, insights, response):
         messages = [{"role": "user", "content": "test"}]
+        insights.capture(response=response, messages=messages)
+        insights._AInsights__client.put.assert_called_once()
+        call_data = insights._AInsights__client.put.call_args[1]["data"]
+        obj = json.loads(call_data)
+        assert obj["messages"] == messages
+
+    def test_capture_args(self, insights, response):
+        args = {"model": "gpt-4o-mini", "temperature": 0.7, "max_tokens": 150}
+        messages = "test message"
         insights.capture(
             response=response,
             messages=messages,
-            user_id="test_user",
+            args=args,
         )
         insights._AInsights__client.put.assert_called_once()
         call_data = insights._AInsights__client.put.call_args[1]["data"]
         obj = json.loads(call_data)
-        assert obj["response"] == response.model_dump()
+        assert obj["args"] == args
+
+    def test_capture_user_id(self, insights, response):
+        user_id = "test_user"
+        messages = [{"role": "user", "content": "test"}]
+        insights.capture(
+            response=response,
+            messages=messages,
+            user_id=user_id,
+        )
+        insights._AInsights__client.put.assert_called_once()
+        call_data = insights._AInsights__client.put.call_args[1]["data"]
+        obj = json.loads(call_data)
+        assert obj["user_id"] == user_id
 
     def test_build(self):
         api_key = "test_key"


### PR DESCRIPTION
Features:
- Allow specifying an extra `meta` dictionary for captured event

Improvements:
- Capture insights via the specialized `ingestion.requesty.ai` domain by default
- Improve unit-test coverage of `capture()`
- `new_client` only uses keyword arguments to avoid mistakes
- `new_client` handles `None` values for `base_url` by assigning the default value