### PR TITLE
Support capturing template and inputs separately

### DIFF
--- a/requestyai/ainsights/client.py
+++ b/requestyai/ainsights/client.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 from openai.types.chat import ChatCompletion
 
 from ..http.async_client import AsyncClient
+from .error import AInsightsValueError
 from .types.event import AInsightsEvent
 
 
@@ -26,20 +27,62 @@ class AInsights:
 
     def capture(
         self,
+        *,
         response: ChatCompletion,
-        messages: Union[str, list[str], list[dict]],
+        messages: Union[None, str, list[str], list[dict]] = None,
+        template: Union[None, str, list[str], list[dict]] = None,
+        inputs: dict = {},
         args: dict = {},
         meta: dict = {},
         user_id: Optional[str] = None,
     ) -> Future:
-        """Capture an event by sending it to the insights endpoint.
-        This method dispatches the event asynchronously, and unless you are
-        debugging any issues, you probably want to ignore the return value.
+        """Capture an AI interaction event and send it to the insights endpoint.
+
+        This method dispatches the event asynchronously. The returned Future object
+        can be ignored unless debugging is needed.
+
+        You should pass to this method one of two argument combinations:
+
+        Option #1 (Recommended): template and inputs
+        Provide the prompt template with the formatting arguments, for example:
+            "Read the following conversation: {conversation}
+             Classify the user's sentiment.
+             Choose only one of the following options: {options}"
+        And the actual user inputs as a dictionary, for example"
+            {
+              "conversation": "Hi, I would like to return my watch ...",
+              "options": "positive, neutral, negative"
+            }
+
+        Option #1: messages-only
+        If you cannot provide the template and user inputs separately,
+        just pass the `messages` argument that you use with the OpenAI client.
+
+        Args:
+            response: The ChatCompletion response from the OpenAI client.
+            messages: The messages argument to the OpenAI client.
+            template: The template used for the interaction.
+            inputs: Dictionary of input parameters used in the interaction.
+            args: Additional arguments used in the interaction.
+            meta: Metadata associated with the interaction.
+            user_id: Optional identifier for the user initiating the interaction.
+
+        Returns:
+            Future: An asynchronous result object representing the HTTP request.
         """
+
+        if (messages is None) and (template is None or inputs is None):
+            message = (
+                "Please specify at least one of "
+                "('messages') or ('template' and 'inputs')"
+            )
+            raise AInsightsValueError(message)
 
         event = AInsightsEvent(
             response=response,
             messages=messages,
+            template=template,
+            inputs=inputs,
             args=args,
             meta=meta,
             user_id=user_id,
@@ -49,9 +92,18 @@ class AInsights:
 
     @staticmethod
     def new_client(*, api_key: str, base_url: Optional[str] = None) -> "AInsights":
-        """The standard way of creating new InsightsClient objects.
-        As the InsightsClient uses dependency injections, this constructor
-        handles the heavy lifting for you
+        """Create a new AInsights client instance with the provided configuration.
+
+        This is the recommended way to create new AInsights instances as it handles
+        all the necessary dependency injection.
+
+        Args:
+            api_key: The API key for authentication with the insights service.
+            base_url: [Optional] custom base URL for the insights service.
+                      Defaults to DEFAULT_BASE_URL if not provided.
+
+        Returns:
+            AInsights: A configured AInsights client instance.
         """
 
         base_url = base_url if base_url is not None else AInsights.DEFAULT_BASE_URL

--- a/requestyai/ainsights/error.py
+++ b/requestyai/ainsights/error.py
@@ -1,0 +1,15 @@
+class AInsightsError(Exception):
+    """Base exception class for AInsights-related errors."""
+
+    pass
+
+
+class AInsightsValueError(AInsightsError):
+    """Exception raised when validation fails for AInsights capture parameters.
+
+    Attributes:
+        message: Explanation of the validation error
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)

--- a/requestyai/ainsights/types/event.py
+++ b/requestyai/ainsights/types/event.py
@@ -6,7 +6,9 @@ from pydantic import BaseModel
 
 class AInsightsEvent(BaseModel):
     response: ChatCompletion
-    messages: Union[str, list[str], list[dict]]
+    messages: Union[None, str, list[str], list[dict]]
+    template: Union[None, str, list[str], list[dict]]
+    inputs: dict
     args: dict
     meta: dict
     user_id: Optional[str]

--- a/samples/openai/format/app.py
+++ b/samples/openai/format/app.py
@@ -1,0 +1,89 @@
+import os
+import uuid
+
+from openai import OpenAI
+
+from requestyai import AInsights
+
+
+def run(*, openai_key, requesty_key, requesty_base_url):
+    ainsights_client = AInsights.new_client(
+        api_key=requesty_key, base_url=requesty_base_url
+    )
+
+    openai_client = OpenAI(api_key=openai_key)
+    openai_args = {"model": "gpt-4o-mini", "temperature": 0.7, "max_tokens": 150}
+
+    template = [
+        {"role": "system", "content": "You help users search the internet."},
+        {
+            "role": "user",
+            "content": "What is the best query to learn more about {subject}",
+        },
+    ]
+
+    user_id = f"user_{uuid.uuid4()}"
+
+    try:
+        while True:
+            subject = input("What information do you want to find online? ")
+            inputs = {"subject": subject}
+
+            messages = [
+                {
+                    "role": message["role"],
+                    "content": message["content"].format(**inputs),
+                }
+                for message in template
+            ]
+
+            response = openai_client.beta.chat.completions.parse(
+                messages=messages, **openai_args
+            )
+
+            ainsights_client.capture(
+                template=template,
+                inputs=inputs,
+                args=openai_args,
+                response=response,
+                user_id=user_id,
+            )
+
+            print(response.choices[0].message.content)
+            print(
+                (
+                    "** See your insights on the Requesty platform: "
+                    "https://app.requesty.ai/chatlogs **"
+                )
+            )
+    except KeyboardInterrupt:
+        print("Terminated...")
+    except Exception as ex:
+        import traceback
+
+        traceback.print_exc()
+        print("Error", ex)
+
+
+def main():
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    if openai_key is None:
+        print("Missing environment variable 'OPENAI_API_KEY'")
+        exit(1)
+
+    requesty_key = os.environ.get("REQUESTY_API_KEY")
+    if requesty_key is None:
+        print("Missing environment variable 'REQUESTY_API_KEY'")
+        exit(1)
+
+    requesty_base_url = os.environ.get("REQUESTY_BASE_URL")
+
+    run(
+        openai_key=openai_key,
+        requesty_key=requesty_key,
+        requesty_base_url=requesty_base_url,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Allow users to capture their prompt templates and dynamic inputs separately.
Consider the following prompt template:
```
    format = [
        {
            "role": "system",
            "content": "You help users search the internet."
        },
        {
            "role": "user",
            "content": "What is the best query to learn more about {subject}",
        },
    ]
```

When the user calls the OpenAI API, the `messages` argument already includes the final formatted string, where `{subject}` is replaced by the actual value.

Instead, allow the user to capture the `format` separately from the actual user input, to drive more flexible analytics and improvements via the platform.